### PR TITLE
fix: remove extraneous `data:` from streaming responses

### DIFF
--- a/src/openai_compat.rs
+++ b/src/openai_compat.rs
@@ -218,10 +218,7 @@ pub async fn chat_completions(
                     finish_reason: None,
                 }],
             };
-            let _ = tx_tokens.send(format!(
-                "data: {}\n\n",
-                serde_json::to_string(&initial_chunk).unwrap()
-            ));
+            let _ = tx_tokens.send(serde_json::to_string(&initial_chunk).unwrap());
 
             // Generate and stream tokens
             let _ = loaded
@@ -243,10 +240,7 @@ pub async fn chat_completions(
                                 finish_reason: None,
                             }],
                         };
-                        let _ = tx_tokens.send(format!(
-                            "data: {}\n\n",
-                            serde_json::to_string(&chunk).unwrap()
-                        ));
+                        let _ = tx_tokens.send(serde_json::to_string(&chunk).unwrap());
                     })),
                 )
                 .await;
@@ -266,11 +260,8 @@ pub async fn chat_completions(
                     finish_reason: Some("stop".to_string()),
                 }],
             };
-            let _ = tx.send(format!(
-                "data: {}\n\n",
-                serde_json::to_string(&final_chunk).unwrap()
-            ));
-            let _ = tx.send("data: [DONE]\n\n".to_string());
+            let _ = tx.send(serde_json::to_string(&final_chunk).unwrap());
+            let _ = tx.send("[DONE]".to_string());
         });
 
         let stream = UnboundedReceiverStream::new(rx)


### PR DESCRIPTION
## Description

Streaming responses contain `data: data:` which breaks OpenAI compatibility as
described in #26. Fix it by removing the extra `data:`.

While there is a (double-posted) [comment](https://github.com/Michael-A-Kuykendall/shimmy/issues/26#issuecomment-3292335159) in #26 claiming that the fix was committed, there's no reference to a corresponding PR or commit, and I don't see any change in the tree.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Shimmy Philosophy Compliance
- [x] Enhances OpenAI API compatibility

## Testing
- [x] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass

The tests don't compile on `main`.
- [ ] I have run `cargo clippy` with no warnings

There are 13 warnings on `main`.
- [ ] I have run `cargo fmt`

`cargo fmt` produces a large number of whitespace changes on `main`.

## Legal Compliance
- [ ] All commits are signed off with DCO (`git commit -s`)

No commits on the main branch have a DCO on them, this doesn't appear to be current practice at all.

- [x] I have the right to contribute this code under the project license
- [x] If this includes third-party code, it's properly attributed and licensed

## Binary Size Impact
No

---

Skipped all these.

## Enterprise Considerations
- [ ] This change maintains backward compatibility
- [ ] Performance impact has been measured and documented
- [ ] Documentation has been updated where applicable
- [ ] Change aligns with roadmap priorities

## Community Impact
- [ ] This change benefits the broader Shimmy community
- [ ] Breaking changes are clearly documented and justified
- [ ] Migration path is provided for breaking changes
New binary size: ___ MB
Change: ± ___ MB

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] This PR addresses an existing issue: #___

## Additional Notes
Any additional information or context for reviewers.