### PR TITLE
Fix OpenAI API compatibility for frontend integration (Issue #113)

### DIFF
--- a/src/openai_compat.rs
+++ b/src/openai_compat.rs
@@ -86,7 +86,15 @@ pub struct Delta {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModelsResponse {
     pub object: String,
-    pub data: Vec<Model>,
+    pub data: Vec<ListModel>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListModel {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub owned_by: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -108,14 +116,14 @@ pub async fn models(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         .registry
         .list_all_available()
         .into_iter()
-        .map(|name| Model {
-            id: name.clone(),
+        .map(|name| ListModel {
+            id: name,
             object: "model".to_string(),
-            created: 0, // Fixed timestamp for simplicity
+            created: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
             owned_by: "shimmy".to_string(),
-            permission: None, // No fine-grained permissions for local models
-            root: Some(name), // The model itself is the root
-            parent: None,     // Local models don't have parent models
         })
         .collect();
 
@@ -714,23 +722,17 @@ mod tests {
         let models_response = ModelsResponse {
             object: "list".to_string(),
             data: vec![
-                Model {
+                ListModel {
                     id: "model1".to_string(),
                     object: "model".to_string(),
                     created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: None,
-                    parent: None,
                 },
-                Model {
+                ListModel {
                     id: "model2".to_string(),
                     object: "model".to_string(),
                     created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: None,
-                    parent: None,
                 },
             ],
         };
@@ -1040,23 +1042,17 @@ mod tests {
         let models_response = ModelsResponse {
             object: "list".to_string(),
             data: vec![
-                Model {
+                ListModel {
                     id: "test-model-1".to_string(),
                     object: "model".to_string(),
-                    created: 0,
+                    created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: None,
-                    parent: None,
                 },
-                Model {
+                ListModel {
                     id: "test-model-2".to_string(),
                     object: "model".to_string(),
-                    created: 0,
+                    created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: None,
-                    parent: None,
                 },
             ],
         };

--- a/tests/regression/issue_113_openai_api.rs
+++ b/tests/regression/issue_113_openai_api.rs
@@ -64,14 +64,11 @@ mod issue_113_tests {
     #[test]
     fn test_openai_models_response_structure() {
         // Test that ModelsResponse matches OpenAI spec
-        let model = Model {
+        let model = shimmy::openai_compat::ListModel {
             id: "test-model".to_string(),
             object: "model".to_string(),
             created: 1640995200,
             owned_by: "shimmy".to_string(),
-            permission: None,
-            root: Some("test-model".to_string()),
-            parent: None,
         };
 
         let response = ModelsResponse {

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -198,23 +198,17 @@ mod regression_tests {
         let models_response = ModelsResponse {
             object: "list".to_string(),
             data: vec![
-                Model {
+                openai_compat::ListModel {
                     id: "qwen3-4b-instruct".to_string(),
                     object: "model".to_string(),
-                    created: 0,
+                    created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: Some("qwen3-4b-instruct".to_string()),
-                    parent: None,
                 },
-                Model {
+                openai_compat::ListModel {
                     id: "llama-7b".to_string(),
                     object: "model".to_string(),
-                    created: 0,
+                    created: 1234567890,
                     owned_by: "shimmy".to_string(),
-                    permission: None,
-                    root: Some("llama-7b".to_string()),
-                    parent: None,
                 },
             ],
         };
@@ -345,9 +339,16 @@ mod regression_tests {
         assert!(json.get("parent").is_none());
 
         // Test ModelsResponse structure
+        let list_model = openai_compat::ListModel {
+            id: "test-model".to_string(),
+            object: "model".to_string(),
+            created: 1640995200,
+            owned_by: "shimmy".to_string(),
+        };
+
         let response = ModelsResponse {
             object: "list".to_string(),
-            data: vec![model],
+            data: vec![list_model],
         };
 
         let response_json = serde_json::to_value(&response).unwrap();


### PR DESCRIPTION
## Summary
Fixes OpenAI API compatibility issues preventing frontend applications like Open WebUI and AnythingLLM from integrating with shimmy.

## Root Cause
Shimmy's  endpoint was returning extra fields (, , ) that aren't part of the OpenAI API specification. Frontend applications that strictly validate API responses were rejecting shimmy as incompatible.

## Changes Made
- **Created  struct**: Separate struct for models endpoint with only OpenAI-compliant fields
- **Updated  response**: Now returns exactly uid=197611(micha) gid=197611 groups=197611, , ,  
- **Fixed timestamps**: Use proper system time instead of hardcoded 0
- **Updated tests**: All tests now use the correct  structure

## API Response Change
**Before:**


**After:**


## Testing
- ✅ All OpenAI compatibility tests pass
- ✅ Release gates pass (all 6 gates)
- ✅ API returns OpenAI specification compliant responses
- ✅ Backward compatibility maintained for internal Model usage

## Issue Link
Closes #113