### PR TITLE
fix: propagate vulkan and opencl features to shimmy-llama-cpp-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ huggingface = [] # Python integration, no additional Rust deps
 mlx = [] # Apple MLX integration for Metal GPU acceleration on Apple Silicon
 # GPU acceleration backends for llama.cpp
 llama-cuda = ["llama", "shimmy-llama-cpp-2/cuda"] # NVIDIA CUDA GPU acceleration
-llama-vulkan = ["llama"] # Vulkan GPU acceleration (cross-platform)
-llama-opencl = ["llama"] # OpenCL GPU acceleration (AMD, Intel, etc.)
+llama-vulkan = ["llama", "shimmy-llama-cpp-2/vulkan"] # Vulkan GPU acceleration (cross-platform)
+llama-opencl = ["llama", "shimmy-llama-cpp-2/opencl"] # OpenCL GPU acceleration (AMD, Intel, etc.)
 # Convenience feature sets
 fast = ["huggingface"] # Fast compilation - no C++ deps
 full = ["huggingface", "llama", "mlx"] # Full compilation - includes all backends
@@ -113,4 +113,5 @@ name = "generation_performance"
 harness = false
 
 [workspace]
+
 


### PR DESCRIPTION
Description

  The llama-vulkan and llama-opencl feature flags in Cargo.toml only enable Rust #[cfg()] gates but do not propagate the corresponding features to
  shimmy-llama-cpp-2. This causes llama.cpp to be compiled without GPU support, silently falling back to CPU even when --gpu-backend vulkan is
  specified.

  The llama-cuda feature already works correctly by including "shimmy-llama-cpp-2/cuda" — this PR applies the same pattern to vulkan and opencl.

  shimmy gpu-info misleadingly reports "✅ Vulkan support enabled" because it checks #[cfg(feature = "llama-vulkan")] (the Rust flag), not the
  actual C++ library capability.

  Related Issue: N/A (no existing issue — discovered during testing)

  Type of Change

  - Bug fix (non-breaking change that fixes an issue)

  Testing

  - I have tested these changes locally
  - I have run cargo test and all tests pass
  - I have run cargo clippy with no warnings
  - I have run cargo fmt

  Before fix (AMD Radeon 890M, RDNA 3.5, gfx1150, Arch Linux):
  - backend_ptrs.size() = 1 (CPU only)
  - All layers assigned to CPU
  - Qwen2.5-Coder-7B Q8_0: ~8.3 tok/s

  After fix:
  - backend_ptrs.size() = 2 (CPU + Vulkan)
  - All layers assigned to Vulkan0
  - Qwen2.5-Coder-7B Q8_0: ~9.6 tok/s (16% faster)
  - Qwen3-Coder-30B-A3B Q4_K_M: 49 layers on Vulkan0, 17.5 GiB GPU buffer

  Binary Size Impact

  Current binary size: 46 MB
  New binary size: 46 MB
  Change: ± 0 MB (no change — same llama.cpp code, just with Vulkan CMake flag enabled)

  Quality Considerations

  - This change maintains backward compatibility
  - Performance impact has been measured and documented
  - Documentation has been updated where applicable
  - Change aligns with roadmap priorities

  Community Impact

  - This change benefits the broader Shimmy community
  - Breaking changes are clearly documented and justified
  - Migration path is provided for breaking changes

  Checklist

  - My code follows the project's coding standards
  - I have read the ../CONTRIBUTING.md guidelines
  - I have added tests for new functionality (if applicable)
  - I have updated documentation (if applicable)
  - This PR addresses an existing issue: N/A

  Additional Notes

  The change is two lines in Cargo.toml:

  -llama-vulkan = ["llama"] # Vulkan GPU acceleration (cross-platform)
  -llama-opencl = ["llama"] # OpenCL GPU acceleration (AMD, Intel, etc.)
  +llama-vulkan = ["llama", "shimmy-llama-cpp-2/vulkan"] # Vulkan GPU acceleration (cross-platform)
  +llama-opencl = ["llama", "shimmy-llama-cpp-2/opencl"] # OpenCL GPU acceleration (AMD, Intel, etc.)

  The feature propagation chain is: shimmy → shimmy-llama-cpp-2/vulkan → shimmy-llama-cpp-sys-2/vulkan → CMake GGML_VULKAN=ON. Without this, the
  C++ build never enables Vulkan regardless of runtime flags.