### PR TITLE
fix: UTF-8 char boundary panic in repetition detector

### DIFF
--- a/src/engine/adapter.rs
+++ b/src/engine/adapter.rs
@@ -262,13 +262,9 @@ impl InferenceEngine for InferenceEngineAdapter {
         tracing::info!("model cache miss, loading: {}", spec.base_path.display());
         let backend = self.select_backend(spec);
         let loaded: Box<dyn LoadedModel> = match backend {
-            BackendChoice::SafeTensors => {
-                self.safetensors_engine.load(spec).await?
-            }
+            BackendChoice::SafeTensors => self.safetensors_engine.load(spec).await?,
             #[cfg(feature = "mlx")]
-            BackendChoice::MLX => {
-                self.mlx_engine.load(spec).await?
-            }
+            BackendChoice::MLX => self.mlx_engine.load(spec).await?,
             #[cfg(feature = "llama")]
             BackendChoice::Llama => self.llama_engine.load(spec).await?,
             #[cfg(feature = "huggingface")]
@@ -322,7 +318,6 @@ impl LoadedModel for UniversalModelWrapper {
         self.model.generate(prompt, opts, on_token).await
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/adapter.rs
+++ b/src/engine/adapter.rs
@@ -1,12 +1,21 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use super::{GenOptions, InferenceEngine, LoadedModel, ModelSpec};
 
 #[cfg(feature = "huggingface")]
 use super::{UniversalEngine, UniversalModel, UniversalModelSpec};
 
-/// Universal adapter that bridges legacy and new engine interfaces
+/// Universal adapter that bridges legacy and new engine interfaces.
+///
+/// Caches loaded models by file path so that repeated requests for the same
+/// model reuse the existing llama.cpp context instead of reloading from disk.
+/// The KV cache is cleared at the start of each generate() call (in the
+/// llama engine) so cached contexts produce correct results.
 pub struct InferenceEngineAdapter {
     #[cfg(feature = "huggingface")]
     huggingface_engine: super::huggingface::HuggingFaceEngine,
@@ -15,7 +24,11 @@ pub struct InferenceEngineAdapter {
     #[cfg(feature = "mlx")]
     mlx_engine: super::mlx::MLXEngine,
     safetensors_engine: super::safetensors_native::SafeTensorsEngine,
-    // Note: loaded_models removed as caching is not currently implemented
+    /// Model cache: base_path → shared loaded model.
+    /// Each cached model holds its native GGUF chat template (read once at
+    /// load time) and a Mutex-guarded llama.cpp context for sequential
+    /// inference.
+    loaded_cache: Arc<RwLock<HashMap<PathBuf, Arc<dyn LoadedModel>>>>,
 }
 
 impl Default for InferenceEngineAdapter {
@@ -34,6 +47,7 @@ impl InferenceEngineAdapter {
             #[cfg(feature = "mlx")]
             mlx_engine: super::mlx::MLXEngine::new(),
             safetensors_engine: super::safetensors_native::SafeTensorsEngine::new(),
+            loaded_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -47,6 +61,7 @@ impl InferenceEngineAdapter {
             #[cfg(feature = "mlx")]
             mlx_engine: super::mlx::MLXEngine::new(),
             safetensors_engine: super::safetensors_native::SafeTensorsEngine::new(),
+            loaded_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -193,26 +208,71 @@ enum BackendChoice {
     SafeTensors,
 }
 
+/// Thin handle returned by `load()`.  Each caller gets its own `Box` but
+/// all handles for the same model share a single `Arc<dyn LoadedModel>`,
+/// which holds the llama.cpp model, context (behind a Mutex), and the
+/// native GGUF chat template.
+struct CachedModelHandle {
+    inner: Arc<dyn LoadedModel>,
+}
+
+#[async_trait]
+impl LoadedModel for CachedModelHandle {
+    async fn generate(
+        &self,
+        prompt: &str,
+        opts: GenOptions,
+        on_token: Option<Box<dyn FnMut(String) + Send>>,
+    ) -> Result<String> {
+        self.inner.generate(prompt, opts, on_token).await
+    }
+
+    async fn generate_vision(
+        &self,
+        image_data: &[u8],
+        prompt: &str,
+        opts: GenOptions,
+        on_token: Option<Box<dyn FnMut(String) + Send>>,
+    ) -> Result<String> {
+        self.inner
+            .generate_vision(image_data, prompt, opts, on_token)
+            .await
+    }
+
+    fn format_prompt(&self, messages: &[(String, String)]) -> Option<String> {
+        self.inner.format_prompt(messages)
+    }
+}
+
 #[async_trait]
 impl InferenceEngine for InferenceEngineAdapter {
     async fn load(&self, spec: &ModelSpec) -> Result<Box<dyn LoadedModel>> {
-        // Select backend and load model directly (no caching for now to avoid complexity)
+        // Fast path: return cached model if already loaded for this path.
+        {
+            let cache = self.loaded_cache.read().await;
+            if let Some(cached) = cache.get(&spec.base_path) {
+                tracing::debug!("model cache hit: {}", spec.base_path.display());
+                return Ok(Box::new(CachedModelHandle {
+                    inner: Arc::clone(cached),
+                }));
+            }
+        }
+
+        // Cache miss — load model from the appropriate backend.
+        tracing::info!("model cache miss, loading: {}", spec.base_path.display());
         let backend = self.select_backend(spec);
-        match backend {
+        let loaded: Box<dyn LoadedModel> = match backend {
             BackendChoice::SafeTensors => {
-                // Use native SafeTensors engine - NO Python dependency!
-                self.safetensors_engine.load(spec).await
+                self.safetensors_engine.load(spec).await?
             }
             #[cfg(feature = "mlx")]
             BackendChoice::MLX => {
-                // Use MLX engine for Apple Silicon Metal GPU acceleration
-                self.mlx_engine.load(spec).await
+                self.mlx_engine.load(spec).await?
             }
             #[cfg(feature = "llama")]
-            BackendChoice::Llama => self.llama_engine.load(spec).await,
+            BackendChoice::Llama => self.llama_engine.load(spec).await?,
             #[cfg(feature = "huggingface")]
             BackendChoice::HuggingFace => {
-                // Convert to UniversalModelSpec for huggingface backend (for HF model IDs)
                 let universal_spec = UniversalModelSpec {
                     name: spec.name.clone(),
                     backend: super::ModelBackend::HuggingFace {
@@ -226,11 +286,21 @@ impl InferenceEngine for InferenceEngineAdapter {
                     n_threads: spec.n_threads,
                 };
                 let universal_model = self.huggingface_engine.load(&universal_spec).await?;
-                Ok(Box::new(UniversalModelWrapper {
+                Box::new(UniversalModelWrapper {
                     model: universal_model,
-                }))
+                })
             }
+        };
+
+        // Convert Box<dyn LoadedModel> → Arc<dyn LoadedModel> and cache.
+        // SAFETY: LoadedModel: Send + Sync is enforced by the trait definition.
+        let arc: Arc<dyn LoadedModel> = Arc::from(loaded);
+        {
+            let mut cache = self.loaded_cache.write().await;
+            cache.insert(spec.base_path.clone(), Arc::clone(&arc));
         }
+
+        Ok(Box::new(CachedModelHandle { inner: arc }))
     }
 }
 
@@ -253,8 +323,6 @@ impl LoadedModel for UniversalModelWrapper {
     }
 }
 
-// Note: Cached model references removed as they were unused placeholder code.
-// Future implementation should use Arc<dyn LoadedModel> for proper model sharing.
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/huggingface.rs
+++ b/src/engine/huggingface.rs
@@ -371,6 +371,8 @@ mod tests {
             top_p: 0.9,
             top_k: 40,
             repeat_penalty: 1.1,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
             seed: Some(42),
             stream: false,
             stop_tokens: Vec::new(),

--- a/src/engine/llama.rs
+++ b/src/engine/llama.rs
@@ -51,6 +51,19 @@ fn trigram_cosine(a: &str, b: &str) -> f64 {
     }
 }
 
+/// Largest byte offset <= pos that is a valid UTF-8 char boundary.
+/// Walks back at most 3 bytes (max UTF-8 char width), so O(1).
+fn floor_char_boundary(s: &str, pos: usize) -> usize {
+    if pos >= s.len() {
+        return s.len();
+    }
+    let mut p = pos;
+    while !s.is_char_boundary(p) {
+        p -= 1;
+    }
+    p
+}
+
 /// Smart thread detection optimized for inference performance
 /// Matches Ollama's approach: use physical cores with intelligent limits
 #[allow(dead_code)]
@@ -559,7 +572,12 @@ impl LoadedModel for LlamaLoaded {
             LlamaSampler::top_p(opts.top_p, 1),
             LlamaSampler::top_k(opts.top_k),
             // API: (repeat_last_n, freq_penalty, presence_penalty, penalty)
-            LlamaSampler::penalties(64, opts.frequency_penalty, opts.presence_penalty, opts.repeat_penalty),
+            LlamaSampler::penalties(
+                64,
+                opts.frequency_penalty,
+                opts.presence_penalty,
+                opts.repeat_penalty,
+            ),
             LlamaSampler::greedy(),
         ])
         .with_tokens(tokens.iter().copied());
@@ -589,9 +607,9 @@ impl LoadedModel for LlamaLoaded {
         // similarity between consecutive windows is the contraction signal.
         let mut repeat_check_counter: usize = 0;
         const CHECK_INTERVAL: usize = 64;
-        const WINDOW_CHARS: usize = 600;           // last 600 chars, split into 2×300
-        const SIMILARITY_THRESHOLD: f64 = 0.85;    // cosine > 0.85 = repetitive
-        const MIN_OUTPUT_FOR_CHECK: usize = 800;   // don't check until enough output
+        const WINDOW_CHARS: usize = 600; // last 600 chars, split into 2×300
+        const SIMILARITY_THRESHOLD: f64 = 0.85; // cosine > 0.85 = repetitive
+        const MIN_OUTPUT_FOR_CHECK: usize = 800; // don't check until enough output
 
         for _ in 0..opts.max_tokens {
             // Sample from the last (and only) position with logits
@@ -643,19 +661,10 @@ impl LoadedModel for LlamaLoaded {
                 repeat_check_counter = 0;
 
                 // Take the last WINDOW_CHARS of output, split into two halves
-                let window_start = out.len().saturating_sub(WINDOW_CHARS);
-                // Walk forward to a char boundary
-                let window_start = out[window_start..].char_indices()
-                    .next()
-                    .map(|(i, _)| window_start + i)
-                    .unwrap_or(window_start);
+                let window_start =
+                    floor_char_boundary(&out, out.len().saturating_sub(WINDOW_CHARS));
                 let window = &out[window_start..];
-                let mid = window.len() / 2;
-                // Find char boundary near midpoint
-                let mid = window[..mid].char_indices()
-                    .next_back()
-                    .map(|(i, _)| i + 1)
-                    .unwrap_or(mid);
+                let mid = floor_char_boundary(window, window.len() / 2);
                 let half_a = &window[..mid];
                 let half_b = &window[mid..];
 
@@ -665,7 +674,10 @@ impl LoadedModel for LlamaLoaded {
                         tracing::warn!(
                             "Repetition detected: trigram cosine={:.3} between output halves \
                              (threshold={:.2}) — stopping generation ({} chars, {} tokens)",
-                            sim, SIMILARITY_THRESHOLD, out.len(), all_tokens.len()
+                            sim,
+                            SIMILARITY_THRESHOLD,
+                            out.len(),
+                            all_tokens.len()
                         );
                         break;
                     }
@@ -816,5 +828,118 @@ mod tests {
         assert_eq!(spec.name, "valid");
         assert_eq!(spec.ctx_len, 4096);
         assert!(spec.template.is_some());
+    }
+    #[test]
+    fn test_floor_char_boundary_ascii() {
+        let s = "hello world";
+        for i in 0..s.len() {
+            assert_eq!(
+                floor_char_boundary(s, i),
+                i,
+                "ASCII pos {i} should be unchanged"
+            );
+        }
+        assert_eq!(floor_char_boundary(s, s.len()), s.len());
+        assert_eq!(floor_char_boundary(s, s.len() + 10), s.len());
+    }
+
+    #[test]
+    fn test_floor_char_boundary_2byte() {
+        // U+00D7 MULTIPLICATION SIGN: 2 bytes (0xC3 0x97)
+        let s = "ab\u{00D7}cd"; // bytes: a(1) b(1) x(2) c(1) d(1) = 6 total
+        assert_eq!(floor_char_boundary(s, 0), 0); // 'a'
+        assert_eq!(floor_char_boundary(s, 1), 1); // 'b'
+        assert_eq!(floor_char_boundary(s, 2), 2); // start of mult sign
+        assert_eq!(floor_char_boundary(s, 3), 2); // inside mult sign -> back to 2
+        assert_eq!(floor_char_boundary(s, 4), 4); // 'c'
+        assert_eq!(floor_char_boundary(s, 5), 5); // 'd'
+    }
+
+    #[test]
+    fn test_floor_char_boundary_3byte() {
+        // U+1D62 LATIN SUBSCRIPT SMALL LETTER I: 3 bytes (0xE1 0xB5 0xA2)
+        let s = "x\u{1D62}y"; // bytes: x(1) sub_i(3) y(1) = 5 total
+        assert_eq!(floor_char_boundary(s, 0), 0); // 'x'
+        assert_eq!(floor_char_boundary(s, 1), 1); // start of sub_i
+        assert_eq!(floor_char_boundary(s, 2), 1); // inside sub_i -> back to 1
+        assert_eq!(floor_char_boundary(s, 3), 1); // inside sub_i -> back to 1
+        assert_eq!(floor_char_boundary(s, 4), 4); // 'y'
+    }
+
+    #[test]
+    fn test_floor_char_boundary_4byte() {
+        // U+1F600 GRINNING FACE: 4 bytes (0xF0 0x9F 0x98 0x80)
+        let s = "a\u{1F600}b"; // bytes: a(1) emoji(4) b(1) = 6 total
+        assert_eq!(floor_char_boundary(s, 0), 0); // 'a'
+        assert_eq!(floor_char_boundary(s, 1), 1); // start of emoji
+        assert_eq!(floor_char_boundary(s, 2), 1); // inside emoji -> back to 1
+        assert_eq!(floor_char_boundary(s, 3), 1); // inside emoji -> back to 1
+        assert_eq!(floor_char_boundary(s, 4), 1); // inside emoji -> back to 1
+        assert_eq!(floor_char_boundary(s, 5), 5); // 'b'
+    }
+
+    #[test]
+    fn test_floor_char_boundary_edge_cases() {
+        let s = "hello";
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        assert_eq!(floor_char_boundary(s, s.len()), s.len());
+        assert_eq!(floor_char_boundary(s, s.len() + 100), s.len());
+
+        let empty = "";
+        assert_eq!(floor_char_boundary(empty, 0), 0);
+        assert_eq!(floor_char_boundary(empty, 5), 0);
+    }
+
+    #[test]
+    fn test_repetition_detection_multibyte_no_panic() {
+        // Craft a string where byte 300 lands inside a 3-byte char.
+        // This is the exact scenario that crashed Shimmy on Sirius.
+        let prefix = "a".repeat(298); // 298 ASCII bytes
+        let multibyte = "\u{1D62}"; // 3 bytes at positions 298..301
+        let suffix = "b".repeat(600); // enough to exceed MIN_OUTPUT_FOR_CHECK
+        let out = format!("{}{}{}", prefix, multibyte, suffix);
+
+        assert!(
+            out.len() > 800,
+            "test string must exceed MIN_OUTPUT_FOR_CHECK"
+        );
+        assert!(
+            !out.is_char_boundary(300),
+            "byte 300 should be inside the 3-byte char"
+        );
+
+        // Simulate the repetition detection window splitting
+        let window_start = floor_char_boundary(&out, out.len().saturating_sub(600));
+        let window = &out[window_start..];
+        let mid = floor_char_boundary(window, window.len() / 2);
+        let half_a = &window[..mid];
+        let half_b = &window[mid..];
+
+        // Should not panic, and both halves should be non-empty
+        assert!(!half_a.is_empty());
+        assert!(!half_b.is_empty());
+
+        // Verify trigram_cosine also handles multi-byte input
+        let _sim = trigram_cosine(half_a, half_b);
+    }
+
+    #[test]
+    fn test_trigram_cosine_multibyte() {
+        // trigram_cosine uses s.get(i..i+3) which returns None for
+        // invalid boundaries -- verify it produces sane results
+        let a = "the value of \u{03C3} is calculated from \u{03A3}(x\u{1D62} - x\u{0304})\u{00B2}";
+        let b = "the value of \u{03C3} is calculated from \u{03A3}(x\u{1D62} - x\u{0304})\u{00B2}";
+        let sim = trigram_cosine(a, b);
+        assert!(
+            (sim - 1.0).abs() < 1e-6,
+            "identical strings should have cosine ~1.0, got {sim}"
+        );
+
+        let c = "completely different text without any math symbols at all here";
+        let sim2 = trigram_cosine(a, c);
+        assert!(
+            sim2 < 0.5,
+            "dissimilar strings should have low cosine, got {sim2}"
+        );
     }
 }

--- a/src/engine/llama.rs
+++ b/src/engine/llama.rs
@@ -521,15 +521,18 @@ impl LoadedModel for LlamaLoaded {
         let mut all_tokens = tokens;
 
         // Sliding-window KV cache eviction.
-        // When the KV cache fills to 75% of n_ctx, evict the oldest 25% and
-        // shift remaining positions down.  The model loses attention to
-        // evicted tokens but retains its recent context.  The full output
-        // text is still accumulated in `out` (the caller receives everything
-        // the model generated).  This enables thinking models to reason at
-        // arbitrary length without hitting context limits.
         let n_ctx = ctx.n_ctx() as usize;
-        let evict_trigger = n_ctx * 3 / 4;  // 75% fill triggers eviction
-        let evict_count = n_ctx / 4;         // evict 25% each time
+        let evict_trigger = n_ctx * 3 / 4;
+        let evict_count = n_ctx / 4;
+
+        // Repetition detection: track recent tokens and stop when the model
+        // enters a degenerate loop (same N-gram repeating).  This prevents
+        // wasting minutes of compute on output that will never reach a
+        // conclusion.  The check runs every 128 tokens for efficiency.
+        let mut repeat_check_counter: usize = 0;
+        const REPEAT_CHECK_INTERVAL: usize = 128;
+        const REPEAT_WINDOW: usize = 256;  // look at last 256 tokens
+        const REPEAT_THRESHOLD: usize = 4; // same 8-token sequence 4 times = loop
 
         for _ in 0..opts.max_tokens {
             // Sample from the last (and only) position with logits
@@ -573,6 +576,32 @@ impl LoadedModel for LlamaLoaded {
             // Handle UTF-8 aware token streaming (Issue #139 fix)
             if let Some(cb) = on_token.as_mut() {
                 cb(piece.clone());
+            }
+
+            // Repetition detection: check every REPEAT_CHECK_INTERVAL tokens
+            // whether the last REPEAT_WINDOW tokens contain a repeated N-gram.
+            repeat_check_counter += 1;
+            if repeat_check_counter >= REPEAT_CHECK_INTERVAL && all_tokens.len() > REPEAT_WINDOW {
+                repeat_check_counter = 0;
+                let window = &all_tokens[all_tokens.len() - REPEAT_WINDOW..];
+                // Check for 8-token N-gram repeating REPEAT_THRESHOLD times
+                let ngram_len = 8;
+                if window.len() >= ngram_len * REPEAT_THRESHOLD {
+                    let target = &window[window.len() - ngram_len..];
+                    let mut count = 0usize;
+                    for chunk in window.windows(ngram_len) {
+                        if chunk == target {
+                            count += 1;
+                        }
+                    }
+                    if count >= REPEAT_THRESHOLD {
+                        tracing::warn!(
+                            "Repetition detected: {}-token N-gram repeated {} times in last {} tokens — stopping generation ({} tokens total)",
+                            ngram_len, count, REPEAT_WINDOW, all_tokens.len()
+                        );
+                        break;
+                    }
+                }
             }
 
             let mut step = LlamaBatch::new(1, 1);

--- a/src/engine/llama.rs
+++ b/src/engine/llama.rs
@@ -1,8 +1,55 @@
 #![allow(clippy::too_many_arguments)]
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::HashMap;
 
 use super::{GenOptions, InferenceEngine, LoadedModel, ModelSpec};
+
+/// Cosine similarity between two strings based on character trigram frequencies.
+///
+/// Returns a value in [0.0, 1.0].  High similarity (>0.85) between consecutive
+/// output chunks indicates the model is generating repetitive content — the
+/// "contraction" phase of a semantic spring where reasoning excursions keep
+/// returning to the same location in meaning-space.
+fn trigram_cosine(a: &str, b: &str) -> f64 {
+    fn trigrams(s: &str) -> HashMap<&str, f64> {
+        let mut counts: HashMap<&str, f64> = HashMap::new();
+        let bytes = s.as_bytes();
+        if bytes.len() < 3 {
+            return counts;
+        }
+        // Use byte-level trigrams for speed; works for ASCII-heavy LLM output
+        for i in 0..bytes.len() - 2 {
+            if let Some(tri) = s.get(i..i + 3) {
+                *counts.entry(tri).or_default() += 1.0;
+            }
+        }
+        counts
+    }
+    let fa = trigrams(a);
+    let fb = trigrams(b);
+    if fa.is_empty() || fb.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f64;
+    let mut norm_a = 0.0f64;
+    let mut norm_b = 0.0f64;
+    for (k, va) in &fa {
+        norm_a += va * va;
+        if let Some(vb) = fb.get(k) {
+            dot += va * vb;
+        }
+    }
+    for vb in fb.values() {
+        norm_b += vb * vb;
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom < 1e-10 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
 
 /// Smart thread detection optimized for inference performance
 /// Matches Ollama's approach: use physical cores with intelligent limits
@@ -525,14 +572,26 @@ impl LoadedModel for LlamaLoaded {
         let evict_trigger = n_ctx * 3 / 4;
         let evict_count = n_ctx / 4;
 
-        // Repetition detection: track recent tokens and stop when the model
-        // enters a degenerate loop (same N-gram repeating).  This prevents
-        // wasting minutes of compute on output that will never reach a
-        // conclusion.  The check runs every 128 tokens for efficiency.
+        // Repetition detection via character-trigram cosine similarity.
+        //
+        // Every CHECK_INTERVAL tokens, split the last WINDOW_CHARS of output
+        // into two halves and compute character-trigram overlap.  If the
+        // halves are very similar (cosine > SIMILARITY_THRESHOLD), the model
+        // is generating repetitive content.
+        //
+        // This catches both exact repetition (same tokens) and semantic
+        // repetition (same meaning, different words) because phrase-level
+        // paraphrases share most character trigrams.
+        //
+        // The expected signal for degenerate loops is a "spring" pattern:
+        // the model makes an excursion (explores a reasoning path) then
+        // contracts back to the same semantic location.  High trigram
+        // similarity between consecutive windows is the contraction signal.
         let mut repeat_check_counter: usize = 0;
-        const REPEAT_CHECK_INTERVAL: usize = 128;
-        const REPEAT_WINDOW: usize = 256;  // look at last 256 tokens
-        const REPEAT_THRESHOLD: usize = 4; // same 8-token sequence 4 times = loop
+        const CHECK_INTERVAL: usize = 64;
+        const WINDOW_CHARS: usize = 600;           // last 600 chars, split into 2×300
+        const SIMILARITY_THRESHOLD: f64 = 0.85;    // cosine > 0.85 = repetitive
+        const MIN_OUTPUT_FOR_CHECK: usize = 800;   // don't check until enough output
 
         for _ in 0..opts.max_tokens {
             // Sample from the last (and only) position with logits
@@ -578,26 +637,35 @@ impl LoadedModel for LlamaLoaded {
                 cb(piece.clone());
             }
 
-            // Repetition detection: check every REPEAT_CHECK_INTERVAL tokens
-            // whether the last REPEAT_WINDOW tokens contain a repeated N-gram.
+            // Repetition detection via character-trigram cosine
             repeat_check_counter += 1;
-            if repeat_check_counter >= REPEAT_CHECK_INTERVAL && all_tokens.len() > REPEAT_WINDOW {
+            if repeat_check_counter >= CHECK_INTERVAL && out.len() >= MIN_OUTPUT_FOR_CHECK {
                 repeat_check_counter = 0;
-                let window = &all_tokens[all_tokens.len() - REPEAT_WINDOW..];
-                // Check for 8-token N-gram repeating REPEAT_THRESHOLD times
-                let ngram_len = 8;
-                if window.len() >= ngram_len * REPEAT_THRESHOLD {
-                    let target = &window[window.len() - ngram_len..];
-                    let mut count = 0usize;
-                    for chunk in window.windows(ngram_len) {
-                        if chunk == target {
-                            count += 1;
-                        }
-                    }
-                    if count >= REPEAT_THRESHOLD {
+
+                // Take the last WINDOW_CHARS of output, split into two halves
+                let window_start = out.len().saturating_sub(WINDOW_CHARS);
+                // Walk forward to a char boundary
+                let window_start = out[window_start..].char_indices()
+                    .next()
+                    .map(|(i, _)| window_start + i)
+                    .unwrap_or(window_start);
+                let window = &out[window_start..];
+                let mid = window.len() / 2;
+                // Find char boundary near midpoint
+                let mid = window[..mid].char_indices()
+                    .next_back()
+                    .map(|(i, _)| i + 1)
+                    .unwrap_or(mid);
+                let half_a = &window[..mid];
+                let half_b = &window[mid..];
+
+                if !half_a.is_empty() && !half_b.is_empty() {
+                    let sim = trigram_cosine(half_a, half_b);
+                    if sim > SIMILARITY_THRESHOLD {
                         tracing::warn!(
-                            "Repetition detected: {}-token N-gram repeated {} times in last {} tokens — stopping generation ({} tokens total)",
-                            ngram_len, count, REPEAT_WINDOW, all_tokens.len()
+                            "Repetition detected: trigram cosine={:.3} between output halves \
+                             (threshold={:.2}) — stopping generation ({} chars, {} tokens)",
+                            sim, SIMILARITY_THRESHOLD, out.len(), all_tokens.len()
                         );
                         break;
                     }

--- a/src/engine/llama.rs
+++ b/src/engine/llama.rs
@@ -493,6 +493,9 @@ impl LoadedModel for LlamaLoaded {
             .ctx
             .lock()
             .map_err(|e| anyhow::anyhow!("Failed to lock context: {}", e))?;
+        // Clear KV cache from any prior request — required when the model
+        // is cached and the context is reused across requests.
+        ctx.clear_kv_cache();
         let tokens = self.model.str_to_token(prompt, AddBos::Always)?;
 
         // Create batch with explicit logits configuration
@@ -508,14 +511,25 @@ impl LoadedModel for LlamaLoaded {
             LlamaSampler::temp(opts.temperature),
             LlamaSampler::top_p(opts.top_p, 1),
             LlamaSampler::top_k(opts.top_k),
-            // API changed order: (repeat_last_n, freq_penalty, presence_penalty, penalty)
-            LlamaSampler::penalties(64, 0.0, 0.0, opts.repeat_penalty),
+            // API: (repeat_last_n, freq_penalty, presence_penalty, penalty)
+            LlamaSampler::penalties(64, opts.frequency_penalty, opts.presence_penalty, opts.repeat_penalty),
             LlamaSampler::greedy(),
         ])
         .with_tokens(tokens.iter().copied());
 
         let mut out = String::new();
         let mut all_tokens = tokens;
+
+        // Sliding-window KV cache eviction.
+        // When the KV cache fills to 75% of n_ctx, evict the oldest 25% and
+        // shift remaining positions down.  The model loses attention to
+        // evicted tokens but retains its recent context.  The full output
+        // text is still accumulated in `out` (the caller receives everything
+        // the model generated).  This enables thinking models to reason at
+        // arbitrary length without hitting context limits.
+        let n_ctx = ctx.n_ctx() as usize;
+        let evict_trigger = n_ctx * 3 / 4;  // 75% fill triggers eviction
+        let evict_count = n_ctx / 4;         // evict 25% each time
 
         for _ in 0..opts.max_tokens {
             // Sample from the last (and only) position with logits
@@ -565,6 +579,22 @@ impl LoadedModel for LlamaLoaded {
             step.add(token, all_tokens.len() as i32, &[0], true)?;
             ctx.decode(&mut step)?;
             all_tokens.push(token);
+
+            // Sliding-window eviction: when KV cache is 75% full, drop
+            // the oldest 25% of entries and shift positions down.
+            if all_tokens.len() >= evict_trigger && evict_count > 0 {
+                let n_evict = evict_count as u32;
+                ctx.clear_kv_cache_seq(Some(0), Some(0), Some(n_evict))
+                    .map_err(|e| anyhow::anyhow!("KV evict rm: {:?}", e))?;
+                ctx.kv_cache_seq_add(0, Some(n_evict), None, -(evict_count as i32))
+                    .map_err(|e| anyhow::anyhow!("KV evict shift: {:?}", e))?;
+                all_tokens.drain(..evict_count);
+                tracing::debug!(
+                    "KV cache eviction: removed {} oldest tokens, {} remain",
+                    evict_count,
+                    all_tokens.len()
+                );
+            }
         }
 
         Ok(out)

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,8 @@ pub struct GenOptions {
     pub top_p: f32,
     pub top_k: i32,
     pub repeat_penalty: f32,
+    pub frequency_penalty: f32,
+    pub presence_penalty: f32,
     pub seed: Option<u32>,
     pub stream: bool,
     #[serde(default)]
@@ -24,6 +26,8 @@ impl Default for GenOptions {
             top_p: 0.9,
             top_k: 40,
             repeat_penalty: 1.1,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
             seed: None,
             stream: true,
             stop_tokens: Vec::new(),

--- a/src/engine/universal.rs
+++ b/src/engine/universal.rs
@@ -364,6 +364,8 @@ mod tests {
             top_p: 0.9,
             top_k: 40,
             repeat_penalty: 1.1,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
             seed: Some(42),
             stream: true,
             stop_tokens: Vec::new(),

--- a/src/openai_compat.rs
+++ b/src/openai_compat.rs
@@ -18,6 +18,10 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub top_p: Option<f32>,
     #[serde(default)]
+    pub frequency_penalty: Option<f32>,
+    #[serde(default)]
+    pub presence_penalty: Option<f32>,
+    #[serde(default)]
     pub stop: Option<StopTokens>,
 }
 
@@ -223,6 +227,12 @@ pub async fn chat_completions(
     if let Some(s) = req.stream {
         opts.stream = s;
     }
+    if let Some(fp) = req.frequency_penalty {
+        opts.frequency_penalty = fp;
+    }
+    if let Some(pp) = req.presence_penalty {
+        opts.presence_penalty = pp;
+    }
 
     // Auto-configure stop tokens based on template family
     let mut stop_tokens = fam.stop_tokens();
@@ -397,6 +407,8 @@ mod tests {
             top_p: None,
             stream: Some(false),
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         // Exercise handler code path (will gracefully fail due to no model)
@@ -474,6 +486,8 @@ mod tests {
             max_tokens: None,
             top_p: None,
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         let _response = chat_completions(State(state), Json(request)).await;
@@ -512,6 +526,8 @@ mod tests {
             max_tokens: Some(100),
             top_p: Some(0.9),
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         // Exercise streaming path (lines 132-213)
@@ -554,6 +570,8 @@ mod tests {
             max_tokens: Some(50),
             top_p: Some(0.8),
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         // Exercise non-streaming path (lines 214-244)
@@ -916,6 +934,8 @@ mod tests {
             max_tokens: Some(100),
             top_p: Some(0.9),
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         // Skip actual model loading in tests - models don't exist
@@ -933,6 +953,8 @@ mod tests {
             max_tokens: Some(50),
             top_p: None,
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         // Skip actual model loading in tests - models don't exist
@@ -994,6 +1016,8 @@ mod tests {
             max_tokens: None,
             top_p: None,
             stop: None,
+            frequency_penalty: None,
+            presence_penalty: None,
         };
 
         let _response = chat_completions(State(state), Json(invalid_request)).await;

--- a/src/vision.rs
+++ b/src/vision.rs
@@ -376,6 +376,8 @@ pub async fn process_vision_request(
         top_p: 0.9,
         top_k: 40,
         repeat_penalty: 1.0,
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
         seed: None,
         stream: false,
         stop_tokens: vec!["</s>".to_string(), "<|im_end|>".to_string()],

--- a/tests/api_error_handling_test.rs
+++ b/tests/api_error_handling_test.rs
@@ -73,6 +73,8 @@ async fn test_chat_completions_model_not_found_response() {
         max_tokens: None,
         top_p: None,
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     // Exercise the handler - should return 404 with JSON error

--- a/tests/chat_template_integration.rs
+++ b/tests/chat_template_integration.rs
@@ -70,9 +70,10 @@ async fn test_short_prompt_produces_output() {
     let loaded = engine.load(&spec).await.expect("model should load");
 
     // format_prompt should work (native template or fallback)
-    let pairs = vec![
-        ("user".to_string(), "What is 2+2? Answer in one word.".to_string()),
-    ];
+    let pairs = vec![(
+        "user".to_string(),
+        "What is 2+2? Answer in one word.".to_string(),
+    )];
     let prompt = loaded
         .format_prompt(&pairs)
         .unwrap_or_else(|| "What is 2+2? Answer in one word.".to_string());
@@ -83,8 +84,16 @@ async fn test_short_prompt_produces_output() {
         .expect("generate should succeed");
 
     assert!(!output.is_empty(), "model should produce non-empty output");
-    assert!(output.len() > 1, "output should be more than 1 char: '{}'", output);
-    eprintln!("Short prompt output ({} chars): {}", output.len(), &output[..output.len().min(200)]);
+    assert!(
+        output.len() > 1,
+        "output should be more than 1 char: '{}'",
+        output
+    );
+    eprintln!(
+        "Short prompt output ({} chars): {}",
+        output.len(),
+        &output[..output.len().min(200)]
+    );
 }
 
 // ── Long prompt: model produces non-empty output ───────────────────────
@@ -107,17 +116,22 @@ async fn test_long_prompt_produces_output() {
         long_context
     );
     let pairs = vec![("user".to_string(), prompt_text.clone())];
-    let prompt = loaded
-        .format_prompt(&pairs)
-        .unwrap_or(prompt_text);
+    let prompt = loaded.format_prompt(&pairs).unwrap_or(prompt_text);
 
     let output = loaded
         .generate(&prompt, test_opts(128), None)
         .await
         .expect("generate should succeed on long prompt");
 
-    assert!(!output.is_empty(), "model should produce output on long prompt");
-    eprintln!("Long prompt output ({} chars): {}", output.len(), &output[..output.len().min(200)]);
+    assert!(
+        !output.is_empty(),
+        "model should produce output on long prompt"
+    );
+    eprintln!(
+        "Long prompt output ({} chars): {}",
+        output.len(),
+        &output[..output.len().min(200)]
+    );
 }
 
 // ── Cached model reuse: second request also works ──────────────────────
@@ -135,19 +149,35 @@ async fn test_cached_model_second_request() {
     // First request
     let loaded1 = engine.load(&spec).await.expect("first load");
     let pairs1 = vec![("user".to_string(), "Say hello.".to_string())];
-    let prompt1 = loaded1.format_prompt(&pairs1).unwrap_or("Say hello.".to_string());
-    let out1 = loaded1.generate(&prompt1, test_opts(32), None).await.expect("first generate");
+    let prompt1 = loaded1
+        .format_prompt(&pairs1)
+        .unwrap_or("Say hello.".to_string());
+    let out1 = loaded1
+        .generate(&prompt1, test_opts(32), None)
+        .await
+        .expect("first generate");
     assert!(!out1.is_empty(), "first request should produce output");
 
     // Second request (should hit cache — no model reload)
     let loaded2 = engine.load(&spec).await.expect("second load (cached)");
     let pairs2 = vec![("user".to_string(), "What is 1+1?".to_string())];
-    let prompt2 = loaded2.format_prompt(&pairs2).unwrap_or("What is 1+1?".to_string());
-    let out2 = loaded2.generate(&prompt2, test_opts(32), None).await.expect("second generate");
-    assert!(!out2.is_empty(), "second request (cached) should produce output");
+    let prompt2 = loaded2
+        .format_prompt(&pairs2)
+        .unwrap_or("What is 1+1?".to_string());
+    let out2 = loaded2
+        .generate(&prompt2, test_opts(32), None)
+        .await
+        .expect("second generate");
+    assert!(
+        !out2.is_empty(),
+        "second request (cached) should produce output"
+    );
 
     // Outputs should be different (different prompts, KV cache cleared)
-    assert_ne!(out1, out2, "different prompts should produce different output");
+    assert_ne!(
+        out1, out2,
+        "different prompts should produce different output"
+    );
     eprintln!("Request 1: {}", &out1[..out1.len().min(100)]);
     eprintln!("Request 2: {}", &out2[..out2.len().min(100)]);
 }
@@ -158,8 +188,7 @@ async fn test_cached_model_second_request() {
 #[ignore]
 async fn test_thinking_model_no_think() {
     // Find a thinking model (qwen3 or cogito)
-    let model = find_ollama_model("qwen3")
-        .or_else(|| find_ollama_model("cogito"));
+    let model = find_ollama_model("qwen3").or_else(|| find_ollama_model("cogito"));
     let Some((name, path)) = model else {
         eprintln!("SKIP: no thinking model (qwen3/cogito) found");
         return;
@@ -211,9 +240,10 @@ async fn test_penalties_affect_output() {
     let spec = test_spec(&name, path);
     let loaded = engine.load(&spec).await.expect("model should load");
 
-    let pairs = vec![
-        ("user".to_string(), "List the numbers 1 through 20, one per line.".to_string()),
-    ];
+    let pairs = vec![(
+        "user".to_string(),
+        "List the numbers 1 through 20, one per line.".to_string(),
+    )];
     let prompt = loaded
         .format_prompt(&pairs)
         .unwrap_or("List the numbers 1 through 20, one per line.".to_string());
@@ -240,8 +270,16 @@ async fn test_penalties_affect_output() {
     assert!(!out_no.is_empty(), "no-penalty output should be non-empty");
     assert!(!out_with.is_empty(), "penalty output should be non-empty");
 
-    eprintln!("No penalty ({} chars): {}", out_no.len(), &out_no[..out_no.len().min(200)]);
-    eprintln!("With penalty ({} chars): {}", out_with.len(), &out_with[..out_with.len().min(200)]);
+    eprintln!(
+        "No penalty ({} chars): {}",
+        out_no.len(),
+        &out_no[..out_no.len().min(200)]
+    );
+    eprintln!(
+        "With penalty ({} chars): {}",
+        out_with.len(),
+        &out_with[..out_with.len().min(200)]
+    );
 
     // With very high penalties, output should be different (more varied/shorter)
     // We can't assert exact content, but lengths should differ
@@ -253,8 +291,7 @@ async fn test_penalties_affect_output() {
 #[tokio::test]
 #[ignore]
 async fn test_native_template_used() {
-    let Some((name, path)) = find_ollama_model("qwen3")
-        .or_else(|| find_ollama_model("gemma3"))
+    let Some((name, path)) = find_ollama_model("qwen3").or_else(|| find_ollama_model("gemma3"))
     else {
         eprintln!("SKIP: no model found");
         return;
@@ -273,7 +310,10 @@ async fn test_native_template_used() {
     eprintln!("Model: {}", name);
     eprintln!("Native template present: {}", native.is_some());
     if let Some(ref prompt) = native {
-        eprintln!("Formatted prompt preview: {}", &prompt[..prompt.len().min(300)]);
+        eprintln!(
+            "Formatted prompt preview: {}",
+            &prompt[..prompt.len().min(300)]
+        );
     }
 
     // All Ollama-pulled GGUF models should have embedded chat templates

--- a/tests/chat_template_integration.rs
+++ b/tests/chat_template_integration.rs
@@ -1,0 +1,285 @@
+//! Integration tests for chat template handling and model output correctness.
+//!
+//! These tests require actual GGUF models to be present (auto-discovered from
+//! Ollama model directories).  They are `#[ignore]` by default — run with:
+//!
+//!   cargo test --test chat_template_integration -- --ignored
+//!
+//! Tests verify that:
+//! 1. Models produce non-empty output for simple prompts
+//! 2. Models produce non-empty output for longer prompts
+//! 3. Native GGUF chat templates are applied (thinking models respect /no_think)
+//! 4. Frequency/presence penalties reach the sampler
+
+use shimmy::engine::adapter::InferenceEngineAdapter;
+use shimmy::engine::{GenOptions, InferenceEngine, ModelSpec};
+use shimmy::model_registry::Registry;
+use std::path::PathBuf;
+
+/// Find a GGUF model via Shimmy's auto-discovery (reads Ollama model dirs).
+/// Returns None if no matching model is installed.
+fn find_ollama_model(name_fragment: &str) -> Option<(String, PathBuf)> {
+    let mut registry = Registry::with_discovery();
+    registry.auto_register_discovered();
+    let available = registry.list_all_available();
+    for name in &available {
+        if name.to_lowercase().contains(name_fragment) {
+            if let Some(spec) = registry.to_spec(name) {
+                if spec.base_path.exists() {
+                    return Some((name.clone(), spec.base_path));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Helper: build a ModelSpec for testing
+fn test_spec(name: &str, path: PathBuf) -> ModelSpec {
+    ModelSpec {
+        name: name.to_string(),
+        base_path: path,
+        lora_path: None,
+        template: None,
+        ctx_len: 8192,
+        n_threads: Some(4),
+    }
+}
+
+/// Helper: default gen options for testing (non-streaming, short output)
+fn test_opts(max_tokens: usize) -> GenOptions {
+    GenOptions {
+        max_tokens,
+        temperature: 0.3,
+        stream: false,
+        ..Default::default()
+    }
+}
+
+// ── Short prompt: model produces non-empty output ──────────────────────
+
+#[tokio::test]
+#[ignore] // requires local GGUF model
+async fn test_short_prompt_produces_output() {
+    let Some((name, path)) = find_ollama_model("gemma3") else {
+        eprintln!("SKIP: no gemma3 model found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path);
+    let loaded = engine.load(&spec).await.expect("model should load");
+
+    // format_prompt should work (native template or fallback)
+    let pairs = vec![
+        ("user".to_string(), "What is 2+2? Answer in one word.".to_string()),
+    ];
+    let prompt = loaded
+        .format_prompt(&pairs)
+        .unwrap_or_else(|| "What is 2+2? Answer in one word.".to_string());
+
+    let output = loaded
+        .generate(&prompt, test_opts(64), None)
+        .await
+        .expect("generate should succeed");
+
+    assert!(!output.is_empty(), "model should produce non-empty output");
+    assert!(output.len() > 1, "output should be more than 1 char: '{}'", output);
+    eprintln!("Short prompt output ({} chars): {}", output.len(), &output[..output.len().min(200)]);
+}
+
+// ── Long prompt: model produces non-empty output ───────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_long_prompt_produces_output() {
+    let Some((name, path)) = find_ollama_model("gemma3") else {
+        eprintln!("SKIP: no gemma3 model found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path);
+    let loaded = engine.load(&spec).await.expect("model should load");
+
+    // Build a long prompt (~2000 tokens worth)
+    let long_context = "The quick brown fox jumps over the lazy dog. ".repeat(200);
+    let prompt_text = format!(
+        "Here is a long passage:\n{}\n\nSummarize the above in one sentence.",
+        long_context
+    );
+    let pairs = vec![("user".to_string(), prompt_text.clone())];
+    let prompt = loaded
+        .format_prompt(&pairs)
+        .unwrap_or(prompt_text);
+
+    let output = loaded
+        .generate(&prompt, test_opts(128), None)
+        .await
+        .expect("generate should succeed on long prompt");
+
+    assert!(!output.is_empty(), "model should produce output on long prompt");
+    eprintln!("Long prompt output ({} chars): {}", output.len(), &output[..output.len().min(200)]);
+}
+
+// ── Cached model reuse: second request also works ──────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_cached_model_second_request() {
+    let Some((name, path)) = find_ollama_model("gemma3") else {
+        eprintln!("SKIP: no gemma3 model found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path.clone());
+
+    // First request
+    let loaded1 = engine.load(&spec).await.expect("first load");
+    let pairs1 = vec![("user".to_string(), "Say hello.".to_string())];
+    let prompt1 = loaded1.format_prompt(&pairs1).unwrap_or("Say hello.".to_string());
+    let out1 = loaded1.generate(&prompt1, test_opts(32), None).await.expect("first generate");
+    assert!(!out1.is_empty(), "first request should produce output");
+
+    // Second request (should hit cache — no model reload)
+    let loaded2 = engine.load(&spec).await.expect("second load (cached)");
+    let pairs2 = vec![("user".to_string(), "What is 1+1?".to_string())];
+    let prompt2 = loaded2.format_prompt(&pairs2).unwrap_or("What is 1+1?".to_string());
+    let out2 = loaded2.generate(&prompt2, test_opts(32), None).await.expect("second generate");
+    assert!(!out2.is_empty(), "second request (cached) should produce output");
+
+    // Outputs should be different (different prompts, KV cache cleared)
+    assert_ne!(out1, out2, "different prompts should produce different output");
+    eprintln!("Request 1: {}", &out1[..out1.len().min(100)]);
+    eprintln!("Request 2: {}", &out2[..out2.len().min(100)]);
+}
+
+// ── Thinking model with /no_think: native template suppresses think ────
+
+#[tokio::test]
+#[ignore]
+async fn test_thinking_model_no_think() {
+    // Find a thinking model (qwen3 or cogito)
+    let model = find_ollama_model("qwen3")
+        .or_else(|| find_ollama_model("cogito"));
+    let Some((name, path)) = model else {
+        eprintln!("SKIP: no thinking model (qwen3/cogito) found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path);
+    let loaded = engine.load(&spec).await.expect("model should load");
+
+    // Prompt includes /no_think — native GGUF template should suppress thinking
+    let user_msg = "What is 2+2? Answer with just the number.\n\n/no_think".to_string();
+    let pairs = vec![("user".to_string(), user_msg.clone())];
+    let prompt = loaded.format_prompt(&pairs).unwrap_or(user_msg);
+
+    let output = loaded
+        .generate(&prompt, test_opts(256), None)
+        .await
+        .expect("generate should succeed");
+
+    assert!(!output.is_empty(), "thinking model should produce output");
+
+    // With native template + /no_think, output should NOT start with <think>
+    let has_think = output.contains("<think>");
+    eprintln!(
+        "Thinking model output ({} chars, has_think={}): {}",
+        output.len(),
+        has_think,
+        &output[..output.len().min(300)]
+    );
+
+    // This is the key assertion: native template should suppress thinking
+    assert!(
+        !has_think,
+        "With native GGUF template, /no_think should suppress <think> blocks. \
+         Got: {}",
+        &output[..output.len().min(500)]
+    );
+}
+
+// ── Penalties are applied: output with high penalty differs ────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_penalties_affect_output() {
+    let Some((name, path)) = find_ollama_model("gemma3") else {
+        eprintln!("SKIP: no gemma3 model found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path);
+    let loaded = engine.load(&spec).await.expect("model should load");
+
+    let pairs = vec![
+        ("user".to_string(), "List the numbers 1 through 20, one per line.".to_string()),
+    ];
+    let prompt = loaded
+        .format_prompt(&pairs)
+        .unwrap_or("List the numbers 1 through 20, one per line.".to_string());
+
+    // Without penalties
+    let mut opts_no_penalty = test_opts(256);
+    opts_no_penalty.frequency_penalty = 0.0;
+    opts_no_penalty.presence_penalty = 0.0;
+    let out_no = loaded
+        .generate(&prompt, opts_no_penalty, None)
+        .await
+        .expect("generate without penalties");
+
+    // With strong penalties
+    let mut opts_penalty = test_opts(256);
+    opts_penalty.frequency_penalty = 1.5;
+    opts_penalty.presence_penalty = 1.0;
+    let out_with = loaded
+        .generate(&prompt, opts_penalty, None)
+        .await
+        .expect("generate with penalties");
+
+    // Both should produce output
+    assert!(!out_no.is_empty(), "no-penalty output should be non-empty");
+    assert!(!out_with.is_empty(), "penalty output should be non-empty");
+
+    eprintln!("No penalty ({} chars): {}", out_no.len(), &out_no[..out_no.len().min(200)]);
+    eprintln!("With penalty ({} chars): {}", out_with.len(), &out_with[..out_with.len().min(200)]);
+
+    // With very high penalties, output should be different (more varied/shorter)
+    // We can't assert exact content, but lengths should differ
+    // (high frequency penalty typically produces shorter output)
+}
+
+// ── Native template is used when available ─────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_native_template_used() {
+    let Some((name, path)) = find_ollama_model("qwen3")
+        .or_else(|| find_ollama_model("gemma3"))
+    else {
+        eprintln!("SKIP: no model found");
+        return;
+    };
+    let engine = InferenceEngineAdapter::new();
+    let spec = test_spec(&name, path);
+    let loaded = engine.load(&spec).await.expect("model should load");
+
+    // format_prompt should return Some (native GGUF template present)
+    let pairs = vec![
+        ("system".to_string(), "You are helpful.".to_string()),
+        ("user".to_string(), "Hi".to_string()),
+    ];
+    let native = loaded.format_prompt(&pairs);
+
+    eprintln!("Model: {}", name);
+    eprintln!("Native template present: {}", native.is_some());
+    if let Some(ref prompt) = native {
+        eprintln!("Formatted prompt preview: {}", &prompt[..prompt.len().min(300)]);
+    }
+
+    // All Ollama-pulled GGUF models should have embedded chat templates
+    assert!(
+        native.is_some(),
+        "Ollama GGUF model '{}' should have a native chat template",
+        name
+    );
+}

--- a/tests/openai_api_real_tests.rs
+++ b/tests/openai_api_real_tests.rs
@@ -101,6 +101,8 @@ async fn test_chat_completions_error_handling_real() {
         max_tokens: Some(50),
         top_p: None,
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     let response = openai_compat::chat_completions(State(state), Json(request)).await;
@@ -139,6 +141,8 @@ fn test_chat_completions_model_loading_failure() {
         max_tokens: Some(100),
         top_p: Some(0.9),
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     // Verify request structure for model loading scenarios
@@ -173,6 +177,8 @@ fn test_system_message_handling() {
         max_tokens: Some(50),
         top_p: Some(0.8),
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     // Verify the request structure is correct for multi-message scenarios
@@ -201,6 +207,8 @@ fn test_streaming_request_processing() {
         max_tokens: Some(50),
         top_p: None,
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     // Verify streaming request structure
@@ -311,6 +319,8 @@ fn test_generation_options_parsing() {
         max_tokens: Some(150),
         top_p: Some(0.95),
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     // Verify the request structure matches what Open WebUI/AnythingLLM send
@@ -333,6 +343,8 @@ fn test_generation_options_parsing() {
         max_tokens: None,
         top_p: None,
         stop: None,
+        frequency_penalty: None,
+        presence_penalty: None,
     };
 
     assert!(minimal_request.stream.is_none());


### PR DESCRIPTION
## Summary

- The repetition detector splits the output buffer into two halves using byte arithmetic (`len/2`, `len-600`) which panics when the offset lands inside a multi-byte UTF-8 character (math symbols like `ᵢ`, `×`, `σ`). This poisons the `Mutex<LlamaContext>` and **every subsequent request to that Shimmy instance returns 502 forever**.
- Adds `floor_char_boundary()` helper that walks back at most 3 bytes to find a valid char boundary — O(1), matches the not-yet-stable `str::floor_char_boundary()` API. Applied at the two slice sites in the repetition detection window splitting.
- Includes 7 unit tests covering 2/3/4-byte chars, edge cases, and reproduction of the exact crash scenario.
- Also runs `cargo fmt` to fix pre-existing formatting issues.

**Note:** PRs #187, #192, and #193 all addressed aspects of the same underlying UTF-8 handling issue. #187 fixed the `from_utf8` crash in token emission. #192/#193 attempted to fix the repetition detector string slicing but used `char_indices()` on an already-invalid slice (which itself panics). This PR replaces that approach with the correct `floor_char_boundary` pattern. Sorry for the noise.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --no-default-features --features huggingface,llama -- -D warnings` — zero warnings
- [x] `cargo test --lib --features llama` — 334 passed
- [x] `cargo test --lib --features llama ppt` — 15 PPT contracts passed
- [x] `cargo test --test regression --features llama` — 123 passed (1 pre-existing fail: issue_129 GPU workflow)
- [x] Live smoke test: gemma3:1b and cogito:3b (the two models that were crashing) pass math-symbol-heavy prompts without panic