### PR TITLE
fix: build 2.3.x from source — use airframe::grammar::grammar_hooks (modify_logits_from_grammar does not exist in any published airframe)

### DIFF
--- a/src/engine/airframe.rs
+++ b/src/engine/airframe.rs
@@ -83,9 +83,23 @@ impl LoadedModel for AirframeModel {
                 .expect("AirframeModel used before engine loaded");
             rt.reset();
 
-            // Build hooks from opts
-            let control = build_control(&opts);
-            let modify_logits = build_modify_logits(&opts);
+            // Build hooks from opts. Grammar mask + control come from
+            // airframe::grammar::grammar_hooks and share one GrammarState
+            // (the mask reads it, the control advances it), so when a
+            // grammar mode is active its control takes precedence over the
+            // FSE reject-pattern control.
+            let fse_control = build_control(&opts);
+            let (modify_logits, grammar_control) = match airframe::grammar::grammar_hooks(
+                &opts.grammar_mode,
+                rt.tokenizer_arc(),
+                rt.spec().n_vocab,
+                rt.eos_token(),
+                rt.im_end_token(),
+            ) {
+                Some((mask, control)) => (Some(mask), Some(control)),
+                None => (None, None),
+            };
+            let control = grammar_control.or(fse_control);
             let trace_cb = build_trace(&opts);
 
             let callback: Option<Box<dyn FnMut(&str) + Send>> = on_token.map(|mut cb| {
@@ -107,10 +121,6 @@ impl LoadedModel for AirframeModel {
 
 fn build_control(opts: &GenOptions) -> Option<Box<dyn airframe::control::InferenceControl + Send + Sync>> {
     airframe::runtime::gpu::fse_control_from_patterns(&opts.fse_reject_patterns)
-}
-
-fn build_modify_logits(opts: &GenOptions) -> Option<Box<dyn Fn(&mut [f32]) + Send + Sync>> {
-    airframe::runtime::gpu::modify_logits_from_grammar(&opts.grammar_mode)
 }
 
 fn build_trace(opts: &GenOptions) -> Option<Box<dyn FnMut(usize, &[f32], f64) + Send>> {


### PR DESCRIPTION
## Problem

`shimmy` 2.3.0/2.3.1 cannot be built from source. `src/engine/airframe.rs` calls

```rust
airframe::runtime::gpu::modify_logits_from_grammar(&opts.grammar_mode)
```

but that function does not exist in any published `airframe` release (0.2.9–0.2.11) nor anywhere in airframe's git history — the 2.3.x releases appear to have been built against an unpublished local airframe state. Combined with the stale `airframe-observe` 0.1.0 publish (see Michael-A-Kuykendall/airframe PR: bump airframe-observe to 0.1.1), `cargo install shimmy` fails for everyone, and the 2.3.x GitHub releases carry no binary assets as fallback.

## Fix

Build the grammar mask and control from `airframe::grammar::grammar_hooks` — the API that published airframe 0.2.11 actually exports. Per its docs both hooks share one `GrammarState` (the pre-sample mask reads it, the post-sample control advances it), so when a grammar mode is active its control takes precedence over the FSE reject-pattern control; with `grammar_mode: "none"` behavior is unchanged (both hooks `None`).

Diff is minimal (17+/7-, CRLF preserved).

## Verified

macOS arm64, rustc 1.97.1, Metal:
- builds against crates.io `airframe` 0.2.11 (with `airframe-observe` patched to git, pending its 0.1.1 publish)
- `shimmy list` auto-discovers 31 local GGUF models (Ollama + LM Studio dirs)
- `shimmy generate … --max-tokens 8` streams tokens through the Airframe/Metal pipeline
